### PR TITLE
use proper callback mutex

### DIFF
--- a/libmosquitto/mosquitto.c
+++ b/libmosquitto/mosquitto.c
@@ -203,7 +203,7 @@ int mosquitto_reinitialise(struct mosquitto *mosq, const char *id, bool clean_se
 	mosq->ssl = NULL;
 	mosq->tls_cert_reqs = SSL_VERIFY_PEER;
 	mosq->tls_insecure = false;
-    mosq->on_verify_tls = NULL;
+	mosq->on_verify_tls = NULL;
 #endif
 #ifdef WITH_THREADING
 	pthread_mutex_init(&mosq->callback_mutex, NULL);
@@ -1080,9 +1080,9 @@ void mosquitto_log_callback_set(struct mosquitto *mosq, void (*on_log)(struct mo
 void mosquitto_verify_ssl_callback_set(struct mosquitto *mosq, bool (*on_verify_tls)(struct mosquitto *, void*, void *, int))
 {
 #ifdef WITH_TLS
-    pthread_mutex_lock(&mosq->callback_mutex);
-    mosq->on_verify_tls = on_verify_tls;
-    pthread_mutex_unlock(&mosq->callback_mutex);
+	pthread_mutex_lock(&mosq->callback_mutex);
+	mosq->on_verify_tls = on_verify_tls;
+	pthread_mutex_unlock(&mosq->callback_mutex);
 #endif
 }
 

--- a/libmosquitto/mosquitto.c
+++ b/libmosquitto/mosquitto.c
@@ -203,6 +203,7 @@ int mosquitto_reinitialise(struct mosquitto *mosq, const char *id, bool clean_se
 	mosq->ssl = NULL;
 	mosq->tls_cert_reqs = SSL_VERIFY_PEER;
 	mosq->tls_insecure = false;
+    mosq->on_verify_tls = NULL;
 #endif
 #ifdef WITH_THREADING
 	pthread_mutex_init(&mosq->callback_mutex, NULL);
@@ -1078,9 +1079,11 @@ void mosquitto_log_callback_set(struct mosquitto *mosq, void (*on_log)(struct mo
 
 void mosquitto_verify_ssl_callback_set(struct mosquitto *mosq, bool (*on_verify_tls)(struct mosquitto *, void*, void *, int))
 {
-    pthread_mutex_lock(&mosq->tls_verify_mutex);
+#ifdef WITH_TLS
+    pthread_mutex_lock(&mosq->callback_mutex);
     mosq->on_verify_tls = on_verify_tls;
-    pthread_mutex_unlock(&mosq->tls_verify_mutex);
+    pthread_mutex_unlock(&mosq->callback_mutex);
+#endif
 }
 
 void mosquitto_user_data_set(struct mosquitto *mosq, void *userdata)

--- a/libmosquitto/mosquitto_internal.h
+++ b/libmosquitto/mosquitto_internal.h
@@ -152,6 +152,7 @@ struct mosquitto {
 	char *tls_psk;
 	char *tls_psk_identity;
 	bool tls_insecure;
+    bool (*on_verify_tls)(struct mosquitto *, void *, void *, int);
 #endif
 	bool want_write;
 #if defined(WITH_THREADING) && !defined(WITH_BROKER)
@@ -162,7 +163,6 @@ struct mosquitto {
 	pthread_mutex_t current_out_packet_mutex;
 	pthread_mutex_t state_mutex;
     pthread_mutex_t message_mutex;
-    pthread_mutex_t tls_verify_mutex;
 	pthread_t thread_id;
 #endif
 #ifdef WITH_BROKER
@@ -188,7 +188,6 @@ struct mosquitto {
 	void (*on_subscribe)(struct mosquitto *, void *userdata, int mid, int qos_count, const int *granted_qos);
 	void (*on_unsubscribe)(struct mosquitto *, void *userdata, int mid);
 	void (*on_log)(struct mosquitto *, void *userdata, int level, const char *str);
-    bool (*on_verify_tls)(struct mosquitto *, void *, void *, int);
 	//void (*on_error)();
 	char *host;
 	int port;

--- a/libmosquitto/mosquitto_internal.h
+++ b/libmosquitto/mosquitto_internal.h
@@ -152,7 +152,7 @@ struct mosquitto {
 	char *tls_psk;
 	char *tls_psk_identity;
 	bool tls_insecure;
-    bool (*on_verify_tls)(struct mosquitto *, void *, void *, int);
+	bool (*on_verify_tls)(struct mosquitto *, void *, void *, int);
 #endif
 	bool want_write;
 #if defined(WITH_THREADING) && !defined(WITH_BROKER)
@@ -162,7 +162,7 @@ struct mosquitto {
 	pthread_mutex_t out_packet_mutex;
 	pthread_mutex_t current_out_packet_mutex;
 	pthread_mutex_t state_mutex;
-    pthread_mutex_t message_mutex;
+	pthread_mutex_t message_mutex;
 	pthread_t thread_id;
 #endif
 #ifdef WITH_BROKER

--- a/libmosquitto/tls_mosq.c
+++ b/libmosquitto/tls_mosq.c
@@ -90,11 +90,13 @@ int _mosquitto_server_certificate_verify_by_callback(int preverify_ok, X509_STOR
 
     bool trustworthy = true;
 
-    pthread_mutex_lock(&mosq->tls_verify_mutex);
+    pthread_mutex_lock(&mosq->callback_mutex);
     if(mosq->on_verify_tls){
+        mosq->in_callback = true;
         trustworthy = mosq->on_verify_tls(mosq, mosq->userdata, ctx, preverify_ok);
+        mosq->in_callback = false;
     }
-    pthread_mutex_unlock(&mosq->tls_verify_mutex);
+    pthread_mutex_unlock(&mosq->callback_mutex);
 
     return trustworthy;
 }


### PR DESCRIPTION
the tls_verify_mutex was never initialized correctly, use the callback_mutex for now.
fix issue #1
